### PR TITLE
Darwin aarch64 hack

### DIFF
--- a/epicsdbbuilder/mydbstatic.py
+++ b/epicsdbbuilder/mydbstatic.py
@@ -64,6 +64,8 @@ def ImportFunctions(epics_base, host_arch):
         }
         bits = platform.architecture()[0]
         host_arch = system_map[(platform.system(), bits)]
+        if platform.system() == 'Darwin' and platform.processor() == 'arm':
+            host_arch = 'darwin-aarch64'
 
     # So we can work with both EPICS 3.14 and 3.15, look for libdbCore.so first
     # before falling back to the older libdbStaticHost.so
@@ -73,6 +75,9 @@ def ImportFunctions(epics_base, host_arch):
     if platform.system() == 'Windows':
         library_name_format = '{}.dll'
         library_location = 'bin'
+    elif platform.system() == 'Darwin':
+        library_name_format = '{}.dylib'
+        library_location = 'lib'
 
     try:
         ImportFunctionsFrom(os.path.join(


### PR DESCRIPTION
1. replace .so with .dylib
2. recognise non-x64 processors

Towards https://github.com/DiamondLightSource/epicsdbbuilder/issues/33

This is in the "ugly but works" category, suspect more elegant solution possible

As mentioned in #33 overriding with environment variable can address point 2, but point 1 needs

```
+    elif platform.system() == 'Darwin':
+        library_name_format = '{}.dylib'
+        library_location = 'lib'
```

at the least